### PR TITLE
Add timeout supports

### DIFF
--- a/celina/widgets/progress.nim
+++ b/celina/widgets/progress.nim
@@ -13,7 +13,7 @@
 ## let percentage = progress.getPercentageText()
 ## ```
 
-import std/[strformat, strutils, unicode, math]
+import std/[strformat, unicode, math]
 
 import base
 import ../core/[geometry, buffer, colors]

--- a/tests/all_tests.nim
+++ b/tests/all_tests.nim
@@ -3,7 +3,7 @@ import
   tapp, tapp_windows, tcelina, terror_handling, tterminal_common, tbutton, ttable,
   ttabs, tprogress, tcursor, tfps, trenderer, ttext, tbase, tlist, tinput,
   tescape_sequence_logic, tkey_logic, tmouse_logic, tresources, tutf8_utils, tconfig,
-  tpaste
+  tpaste, ttick_common
 
 import ../celina/async/async_backend
 

--- a/tests/tapp.nim
+++ b/tests/tapp.nim
@@ -480,6 +480,82 @@ suite "App handleWindowEvent":
     # so returns false (resize is typically handled separately via dispatchResize)
     check app.handleWindowEvent(event) == false
 
+suite "App Application Timeout":
+  test "applicationTimeout default is 0":
+    let app = newApp()
+    check app.getApplicationTimeout() == 0
+
+  test "setApplicationTimeout and getApplicationTimeout":
+    let app = newApp()
+    app.setApplicationTimeout(500)
+    check app.getApplicationTimeout() == 500
+
+    app.setApplicationTimeout(0)
+    check app.getApplicationTimeout() == 0
+
+  test "setApplicationTimeout can update value multiple times":
+    let app = newApp()
+    app.setApplicationTimeout(100)
+    check app.getApplicationTimeout() == 100
+
+    app.setApplicationTimeout(200)
+    check app.getApplicationTimeout() == 200
+
+    app.setApplicationTimeout(0)
+    check app.getApplicationTimeout() == 0
+
+  test "onTimeout sets timeout handler":
+    let app = newApp()
+    var handlerCalled = false
+
+    app.onTimeout proc(app: App): bool =
+      handlerCalled = true
+      return true
+
+    # Handler is set but not called until run
+    check handlerCalled == false
+
+  test "onTimeout replaces previous handler":
+    let app = newApp()
+    var firstCalled = false
+    var secondCalled = false
+
+    app.onTimeout proc(app: App): bool =
+      firstCalled = true
+      return true
+
+    app.onTimeout proc(app: App): bool =
+      secondCalled = true
+      return true
+
+    # Both are set but neither called; second should have replaced first
+    check firstCalled == false
+    check secondCalled == false
+
+  test "onTimeout handler can disable timeout by setting 0":
+    let app = newApp()
+    app.setApplicationTimeout(100)
+
+    app.onTimeout proc(app: App): bool =
+      app.setApplicationTimeout(0)
+      return true
+
+    check app.getApplicationTimeout() == 100
+
+  test "setApplicationTimeout does not affect handler registration":
+    let app = newApp()
+    var handlerSet = false
+
+    app.onTimeout proc(app: App): bool =
+      handlerSet = true
+      return true
+
+    app.setApplicationTimeout(0)
+    app.setApplicationTimeout(500)
+    # Handler should still be registered regardless of timeout value changes
+    check handlerSet == false
+    check app.getApplicationTimeout() == 500
+
 suite "App String Representation":
   test "new app string representation":
     let app = newApp()

--- a/tests/tasync_app.nim
+++ b/tests/tasync_app.nim
@@ -438,6 +438,82 @@ when hasAsyncSupport:
       check app.getCursorPosition() == (-1, -1)
       check app.getCursorStyle() == CursorStyle.Default
 
+  suite "AsyncApp Application Timeout":
+    test "applicationTimeout default is 0":
+      let app = newAsyncApp()
+      check app.getApplicationTimeout() == 0
+
+    test "setApplicationTimeout and getApplicationTimeout":
+      let app = newAsyncApp()
+      app.setApplicationTimeout(500)
+      check app.getApplicationTimeout() == 500
+
+      app.setApplicationTimeout(0)
+      check app.getApplicationTimeout() == 0
+
+    test "setApplicationTimeout can update value multiple times":
+      let app = newAsyncApp()
+      app.setApplicationTimeout(100)
+      check app.getApplicationTimeout() == 100
+
+      app.setApplicationTimeout(200)
+      check app.getApplicationTimeout() == 200
+
+      app.setApplicationTimeout(0)
+      check app.getApplicationTimeout() == 0
+
+    test "onTimeoutAsync sets timeout handler":
+      let app = newAsyncApp()
+      var handlerCalled = false
+
+      app.onTimeoutAsync proc(app: AsyncApp): Future[bool] {.async.} =
+        handlerCalled = true
+        return true
+
+      # Handler is set but not called until run
+      check handlerCalled == false
+
+    test "onTimeoutAsync replaces previous handler":
+      let app = newAsyncApp()
+      var firstCalled = false
+      var secondCalled = false
+
+      app.onTimeoutAsync proc(app: AsyncApp): Future[bool] {.async.} =
+        firstCalled = true
+        return true
+
+      app.onTimeoutAsync proc(app: AsyncApp): Future[bool] {.async.} =
+        secondCalled = true
+        return true
+
+      # Both are set but neither called; second should have replaced first
+      check firstCalled == false
+      check secondCalled == false
+
+    test "onTimeoutAsync handler can disable timeout by setting 0":
+      let app = newAsyncApp()
+      app.setApplicationTimeout(100)
+
+      app.onTimeoutAsync proc(app: AsyncApp): Future[bool] {.async.} =
+        app.setApplicationTimeout(0)
+        return true
+
+      check app.getApplicationTimeout() == 100
+
+    test "setApplicationTimeout does not affect handler registration":
+      let app = newAsyncApp()
+      var handlerSet = false
+
+      app.onTimeoutAsync proc(app: AsyncApp): Future[bool] {.async.} =
+        handlerSet = true
+        return true
+
+      app.setApplicationTimeout(0)
+      app.setApplicationTimeout(500)
+      # Handler should still be registered regardless of timeout value changes
+      check handlerSet == false
+      check app.getApplicationTimeout() == 500
+
   suite "AsyncApp handleWindowEvent":
     test "handleWindowEvent with no window mode returns false":
       let app = newAsyncApp()

--- a/tests/ttick_common.nim
+++ b/tests/ttick_common.nim
@@ -1,0 +1,88 @@
+## Tests for tick_common module
+
+import std/unittest
+
+import ../celina/core/tick_common
+
+suite "clampTimeout":
+  test "returns timeout when above minimum":
+    check clampTimeout(10, 1) == 10
+    check clampTimeout(100, 1) == 100
+
+  test "returns minTimeout when timeout is at or below minimum":
+    check clampTimeout(0, 1) == 1
+    check clampTimeout(1, 1) == 1
+    check clampTimeout(-5, 1) == 1
+
+  test "default minTimeout is 0":
+    check clampTimeout(5) == 5
+    check clampTimeout(0) == 0
+    check clampTimeout(-1) == 0
+
+suite "ResizeState":
+  test "initResizeState sets initial counter":
+    var state = initResizeState(42)
+    check state.lastCounter == 42
+
+  test "checkResize returns true when counter changes":
+    var state = initResizeState(0)
+    check state.checkResize(1) == true
+    check state.lastCounter == 1
+
+  test "checkResize returns false when counter unchanged":
+    var state = initResizeState(5)
+    check state.checkResize(5) == false
+
+  test "checkResize detects multiple resizes":
+    var state = initResizeState(0)
+    check state.checkResize(1) == true
+    check state.checkResize(1) == false
+    check state.checkResize(2) == true
+    check state.checkResize(2) == false
+
+suite "calculatePollTimeout":
+  test "no application timeout returns remainingFrameTime":
+    check calculatePollTimeout(16, 0, 0) == 16
+    check calculatePollTimeout(100, 0, 500) == 100
+
+  test "application timeout larger than frame time returns frame time":
+    # 500ms timeout, 0ms elapsed, 16ms frame time → min(16, 500) = 16
+    check calculatePollTimeout(16, 500, 0) == 16
+
+  test "remaining timeout smaller than frame time returns remaining timeout":
+    # 500ms timeout, 490ms elapsed → 10ms remaining, frame time 16ms → 10
+    check calculatePollTimeout(16, 500, 490) == 10
+
+  test "timeout already reached returns 0":
+    # 500ms timeout, 500ms elapsed → 0ms remaining
+    check calculatePollTimeout(16, 500, 500) == 0
+    # 500ms timeout, 600ms elapsed → still 0 (clamped by max)
+    check calculatePollTimeout(16, 500, 600) == 0
+
+  test "both values equal returns that value":
+    check calculatePollTimeout(100, 200, 100) == 100
+
+  test "frame time is 0":
+    check calculatePollTimeout(0, 500, 0) == 0
+
+  test "negative application timeout treated as disabled":
+    # applicationTimeout <= 0 takes the else branch
+    check calculatePollTimeout(16, -1, 100) == 16
+
+suite "isTimeoutReached":
+  test "returns false when timeout is disabled":
+    check isTimeoutReached(0, 1000) == false
+
+  test "returns false when elapsed is less than timeout":
+    check isTimeoutReached(500, 200) == false
+    check isTimeoutReached(500, 499) == false
+
+  test "returns true when elapsed equals timeout":
+    check isTimeoutReached(500, 500) == true
+
+  test "returns true when elapsed exceeds timeout":
+    check isTimeoutReached(500, 600) == true
+    check isTimeoutReached(100, 5000) == true
+
+  test "returns false when timeout is negative":
+    check isTimeoutReached(-1, 100) == false


### PR DESCRIPTION
  Allow apps to register a timeout handler that fires after a configurable period of input inactivity.