### PR TITLE
Re-create input reader on a second runAsync instead of reusing a clos…

### DIFF
--- a/celina/async/async_app.nim
+++ b/celina/async/async_app.nim
@@ -6,7 +6,8 @@
 import std/[options, monotimes, times, strformat]
 
 import async_backend, async_terminal, async_events, async_renderer
-from async_io import AsyncInputReader, newAsyncInputReader, closeAsyncInputReader
+from async_io import
+  AsyncInputReader, newAsyncInputReader, closeAsyncInputReader, isLive
 import
   ../core/[
     geometry, buffer, events, fps, config, tick_common, cursor, terminal,
@@ -140,6 +141,13 @@ defineTimeoutHandlerSettersAsync(AsyncApp)
 defineTimeoutAccessors(AsyncApp)
 
 # AsyncApp Lifecycle Management
+
+proc isInputReaderLive*(app: AsyncApp): bool =
+  ## Whether the app currently holds a live input reader. Outside an active
+  ## run this is false (the reader is created in `setupAsync` and dropped in
+  ## `runAsyncInner` cleanup). Mainly useful for tests asserting that a second
+  ## `runAsync` re-creates a usable reader instead of reusing a closed one.
+  app.inputReader.isLive()
 
 proc setupAsync(app: AsyncApp) {.async.} =
   if app.inputReader.isNil:
@@ -418,6 +426,7 @@ proc runAsyncInner(app: AsyncApp) {.async.} =
     app.state.running = false
     await cleanupQuietly(app)
     app.inputReader.closeAsyncInputReader()
+    app.inputReader = nil
     when hasChronos and defined(posix):
       removeSignalHandlers(app)
 

--- a/celina/async/async_io.nim
+++ b/celina/async/async_io.nim
@@ -40,6 +40,13 @@ proc newAsyncInputReader*(): AsyncInputReader =
     result.usePolling = true
     result.selectorRegistered = false
 
+proc isLive*(reader: AsyncInputReader): bool =
+  ## Whether `reader` can still observe input. False for a nil reader or one
+  ## that has been through `closeAsyncInputReader` (which nils `selector`).
+  ## A polling-mode reader stays usable via direct `poll()`, so it is live as
+  ## long as the object exists.
+  not reader.isNil and (reader.usePolling or reader.selector != nil)
+
 proc closeAsyncInputReader*(reader: AsyncInputReader) =
   ## Close the async input reader. Safe to call on a nil reader and safe
   ## to call repeatedly: after the first call `reader.selector` is set to

--- a/tests/tasync_app.nim
+++ b/tests/tasync_app.nim
@@ -913,6 +913,33 @@ when hasAsyncSupport:
       app.restoreTerminal()
       app.restoreTerminal()
 
+  suite "AsyncApp Input Reader Lifecycle":
+    test "runAsync re-creates a live input reader on a second run":
+      ## Regression: cleanup closes the input reader, niling its selector; the
+      ## app must also drop the reference so a second `runAsync` builds a fresh
+      ## live reader instead of reusing the closed one. Reuse left
+      ## `hasDataAvailable` permanently false, silently swallowing all input on
+      ## every run after the first.
+      let config = AppConfig(alternateScreen: false, rawMode: false, targetFps: 60)
+      let app = newAsyncApp(config)
+
+      var liveDuringRun = false
+      app.onTickAsync proc(app: AsyncApp): Future[bool] {.async.} =
+        liveDuringRun = app.isInputReaderLive()
+        app.quit()
+        return true
+
+      # First run: reader is live mid-run, then dropped on completion.
+      waitFor app.runAsync()
+      check liveDuringRun == true
+      check app.isInputReaderLive() == false
+
+      # Second run must rebuild a live reader rather than reuse the closed one.
+      liveDuringRun = false
+      waitFor app.runAsync()
+      check liveDuringRun == true
+      check app.isInputReaderLive() == false
+
   when hasChronos:
     import chronos
 


### PR DESCRIPTION
…ed one